### PR TITLE
use ubuntu 22.04 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             buildname: 'Linux'
             triplet: x64-linux
             compiler: clang_64


### PR DESCRIPTION
Some research by SlySven indicated that linuxdeployqt may have been fixed to work with ubuntu 22.04 image