### PR TITLE
Update macOS runner from macos-13 to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
             triplet: x64-linux
             compiler: clang_64
             qt: '6.9.1'
-          - os: macos-13
+          - os: macos-15
             buildname: 'macOS'
-            triplet: x64-osx
+            triplet: arm64-osx
             compiler: clang_64
             qt: '6.9.1'
           - os: windows-2025


### PR DESCRIPTION
The macOS-13 runner has been retired by GitHub Actions. Updated to macos-15 which uses Apple Silicon (arm64) and changed the triplet from x64-osx to arm64-osx accordingly.

See: https://github.com/actions/runner-images/issues/13046